### PR TITLE
Add type checking for RegExp

### DIFF
--- a/example.js
+++ b/example.js
@@ -18,3 +18,4 @@ function* generator(i) {
 
 console.log(is.promise(promise));
 console.log(is.generatorFunction(generator(10)));
+console.log(is.regExp(/\.js$/));

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var methods = {
   'string': isString,
   'symbol': isSymbol,
   'boolean': isBoolean,
-  'error': isError
+  'error': isError,
+  'regExp': isRegExp
 };
 
 
@@ -149,4 +150,17 @@ function isBoolean(val) {
 
 function isError(val) {
   return Error == val.constructor;
+}
+
+/**
+ * Check for plain regex
+ *
+ * @param {Mixed} val
+ * @return {Boolean}
+ * @api private
+ *
+*/
+
+function isRegExp(val) {
+  return RegExp == val.constructor;
 }


### PR DESCRIPTION
#### What does this PR do?
This PR adds regular expression type checking.

#### How to test
```
const is = require('is');

console.log(is.regExp(/\.js$/));
// -> true
```